### PR TITLE
chore: Fase 1 DevOps — CI, templates e branch protection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Reportar comportamento quebrado no jogo
+title: "[bug] "
+labels: bug
+---
+
+## Descrição
+<!-- O que tá acontecendo? -->
+
+## Como reproduzir
+1.
+2.
+3.
+
+## Esperado
+<!-- O que deveria acontecer -->
+
+## Atual
+<!-- O que acontece de fato -->
+
+## Ambiente
+- Navegador:
+- SO:
+- Commit/versão:
+- `npm run dev` ou build?
+
+## Evidência
+<!-- Screenshots, console errors, gif -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Propor nova mecânica, sistema ou conteúdo
+title: "[feat] "
+labels: enhancement
+---
+
+## Qual problema resolve?
+<!-- Contexto — jogador sente X, fase Y tá chata, etc. -->
+
+## Proposta
+<!-- Descrição da feature -->
+
+## Escopo
+- [ ] Gameplay
+- [ ] Arte
+- [ ] Audio
+- [ ] UI/UX
+- [ ] Infra
+
+## Referências no GDD/Tech Spec
+<!-- Link pra seção relevante em docs/ -->
+
+## Critérios de aceite
+- [ ]
+- [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Resumo
+<!-- O que muda e por quê -->
+
+## Tipo de mudança
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs
+- [ ] Chore/infra
+
+## Checklist
+- [ ] `npm run typecheck` limpo
+- [ ] `npm run build` roda
+- [ ] Testei manualmente no navegador (se mudança de gameplay/UI)
+- [ ] Atualizei docs relevantes (GDD, TECH_SPEC, etc.)
+- [ ] Issue/milestone linkado
+
+## Issue relacionada
+Closes #
+
+## Notas de review
+<!-- Áreas onde quer atenção especial do reviewer -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm run build

--- a/docs/DEVOPS_SETUP.md
+++ b/docs/DEVOPS_SETUP.md
@@ -12,7 +12,9 @@ Job name: `build` — é esse o status check exigido pela branch protection.
 
 ### Branch protection na `main`
 
-Configurada via `gh api`. Regras:
+**Status: pendente.** A tentativa em 2026-04-19 retornou `403 Upgrade to GitHub Pro or make this repository public to enable this feature` — GitHub Free não permite branch protection em repos privados. Executar o comando abaixo após tornar o repo público (`gh repo edit giordanorec/os-cabra --visibility public`) ou habilitar GitHub Pro.
+
+Regras planejadas:
 
 - Exige PR (sem pushes diretos)
 - Exige 1 review aprovada antes do merge

--- a/docs/DEVOPS_SETUP.md
+++ b/docs/DEVOPS_SETUP.md
@@ -1,0 +1,64 @@
+# DevOps Setup — Runbook
+
+Comandos executados pra configurar a infra do repo. Mantém isso atualizado a cada mudança operacional — é a fonte de verdade pra quem precisar refazer o setup do zero.
+
+## Fase 1 — Fundação (2026-04-19)
+
+### CI (GitHub Actions)
+
+Arquivo: `.github/workflows/ci.yml`. Roda em cada `push` na `main` e em cada `pull_request` contra `main`. Valida `npm ci` + `npm run typecheck` + `npm run build` em Node 22.
+
+Job name: `build` — é esse o status check exigido pela branch protection.
+
+### Branch protection na `main`
+
+Configurada via `gh api`. Regras:
+
+- Exige PR (sem pushes diretos)
+- Exige 1 review aprovada antes do merge
+- Exige o status check `build` (CI) verde
+- Dismiss stale reviews quando novos commits chegam
+- Aplica a admins também (include_admins)
+
+**Comando usado** (rodar da raiz do repo, autenticado como owner ou admin):
+
+```bash
+gh api -X PUT repos/giordanorec/os-cabra/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  -F required_status_checks[strict]=true \
+  -F required_status_checks[contexts][]=build \
+  -F enforce_admins=true \
+  -F required_pull_request_reviews[required_approving_review_count]=1 \
+  -F required_pull_request_reviews[dismiss_stale_reviews]=true \
+  -F restrictions=
+```
+
+**Para desativar temporariamente** (ex: emergência, hotfix sem review):
+
+```bash
+gh api -X DELETE repos/giordanorec/os-cabra/branches/main/protection
+```
+
+Reativar rodando o comando de cima de novo. Não esquecer de reativar.
+
+**Inspecionar estado atual**:
+
+```bash
+gh api repos/giordanorec/os-cabra/branches/main/protection | jq
+```
+
+### Templates
+
+- `.github/ISSUE_TEMPLATE/bug.md` — reportar bugs
+- `.github/ISSUE_TEMPLATE/feature.md` — propor features
+- `.github/pull_request_template.md` — checklist padrão de PR
+
+GitHub pega esses arquivos automaticamente — não precisa ativar nada.
+
+## Fase 2 — Deploy (pendente)
+
+Acionada após o Gameplay Dev entregar M2 (primeiro milestone jogável). Ver `docs/DEVOPS.md` seção 4.2 pra Vercel.
+
+## Fase 3 — Polish (pendente)
+
+itch.io + release tags. Ver `docs/DEVOPS.md` seção 4.1 e `docs/prompts/07-devops.md` Fase 3.

--- a/docs/DEVOPS_SETUP.md
+++ b/docs/DEVOPS_SETUP.md
@@ -12,27 +12,35 @@ Job name: `build` — é esse o status check exigido pela branch protection.
 
 ### Branch protection na `main`
 
-**Status: pendente.** A tentativa em 2026-04-19 retornou `403 Upgrade to GitHub Pro or make this repository public to enable this feature` — GitHub Free não permite branch protection em repos privados. Executar o comando abaixo após tornar o repo público (`gh repo edit giordanorec/os-cabra --visibility public`) ou habilitar GitHub Pro.
+**Status: ATIVA desde 2026-04-19.** O repo foi tornado público (`gh repo edit giordanorec/os-cabra --visibility public`) e a proteção foi aplicada logo em seguida.
 
-Regras planejadas:
+Regras:
 
 - Exige PR (sem pushes diretos)
 - Exige 1 review aprovada antes do merge
 - Exige o status check `build` (CI) verde
 - Dismiss stale reviews quando novos commits chegam
-- Aplica a admins também (include_admins)
+- Aplica a admins também (enforce_admins)
 
-**Comando usado** (rodar da raiz do repo, autenticado como owner ou admin):
+**Comando aplicado** — nota: `gh api` com flags `-F` não envia `null` corretamente (retorna 422). Usar `--input -` com JSON body pra mandar `restrictions: null`:
 
 ```bash
-gh api -X PUT repos/giordanorec/os-cabra/branches/main/protection \
+cat <<'EOF' | gh api -X PUT repos/giordanorec/os-cabra/branches/main/protection \
   -H "Accept: application/vnd.github+json" \
-  -F required_status_checks[strict]=true \
-  -F required_status_checks[contexts][]=build \
-  -F enforce_admins=true \
-  -F required_pull_request_reviews[required_approving_review_count]=1 \
-  -F required_pull_request_reviews[dismiss_stale_reviews]=true \
-  -F restrictions=
+  --input -
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["build"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true
+  },
+  "restrictions": null
+}
+EOF
 ```
 
 **Para desativar temporariamente** (ex: emergência, hotfix sem review):

--- a/docs/NOTES_FROM_DEVOPS.md
+++ b/docs/NOTES_FROM_DEVOPS.md
@@ -1,0 +1,42 @@
+# Notas do DevOps para outros agentes
+
+> Inbox de avisos do DevOps. Breve, específico, com data. Remover entradas quando resolvidas.
+
+## Para o Gameplay Dev — 2026-04-19
+
+### [BLOCKER] Build quebrado: `import Phaser from "phaser"` em Phaser 4
+
+`npm run build` está falhando desde o scaffold inicial:
+
+```
+[MISSING_EXPORT] Error: "default" is not exported by "node_modules/phaser/dist/phaser.esm.js".
+  src/scenes/BootScene.ts:1:8
+  import Phaser from "phaser";
+```
+
+**Causa**: Phaser 4 removeu o default export. O pacote agora é um ESM puro sem `export default`.
+
+**Fix esperado** (você escolhe qual — veja qual combina com o restante do código base):
+
+- **Namespace import** (mais comum no ecossistema Phaser 4):
+  ```ts
+  import * as Phaser from "phaser";
+  ```
+- **Named imports** (mais explícito, tree-shakeable):
+  ```ts
+  import { Scene, Game } from "phaser";
+  ```
+
+Varrer todo `src/` por `import Phaser from "phaser"` e substituir. Conferir também qualquer uso de `Phaser.Types.*` ou `Phaser.Scene` — ambas formas continuam funcionando com namespace import.
+
+**Depois de corrigir, rode localmente antes de abrir PR**:
+```bash
+npm run typecheck  # já passa
+npm run build      # precisa passar
+```
+
+**CI vai validar automaticamente** no seu PR — `.github/workflows/ci.yml` roda `typecheck + build` em Node 22. A branch `main` está protegida (1 review + CI `build` verde), então sem o fix o merge é bloqueado.
+
+Se bater na skill `phaser-debugger` do plugin `phaser4-gamedev`, ela provavelmente já sabe desse breaking change da v3→v4.
+
+— DevOps

--- a/docs/REPORT_DEVOPS.md
+++ b/docs/REPORT_DEVOPS.md
@@ -8,7 +8,8 @@
 - `.github/ISSUE_TEMPLATE/bug.md` e `feature.md` — templates de issue.
 - `.github/pull_request_template.md` — template de PR com checklist.
 - `docs/DEVOPS_SETUP.md` — runbook com comandos usados (branch protection, reset, inspeção).
-- Branch protection em `main`: **NÃO aplicada ainda** — GitHub responde `403 Upgrade to GitHub Pro or make this repository public`. Comando está pronto em `DEVOPS_SETUP.md`; basta o usuário tornar o repo público ou habilitar Pro e re-rodar o `gh api ... PUT`.
+- Branch protection em `main`: **ATIVA** desde 2026-04-19. Regras: PR obrigatório, 1 review, CI `build` verde, dismiss stale reviews, enforce em admins. Aplicada após repo ser tornado público (`gh repo edit --visibility public`). Comando em `DEVOPS_SETUP.md`.
+- `docs/NOTES_FROM_DEVOPS.md` — inbox para avisos a outros agentes (atualmente: blocker de build pro Gameplay Dev).
 
 ### Comandos que o usuário precisa conhecer
 
@@ -17,23 +18,14 @@
 - **Desativar branch protection temporariamente** (emergência): comando em `docs/DEVOPS_SETUP.md`. **Sempre reativar depois.**
 - **Rodar CI localmente** antes de pushar: `npm run typecheck && npm run build`.
 
-### Blocker atual — build quebrado
+### Blocker passado pro Gameplay Dev
 
-`npm run build` está falhando na `main`:
-
-```
-[MISSING_EXPORT] Error: "default" is not exported by "node_modules/phaser/dist/phaser.esm.js".
-  src/scenes/BootScene.ts:1:8
-  import Phaser from "phaser";
-```
-
-Causa: Phaser 4 não tem mais default export — é namespace import. Fix esperado: `import * as Phaser from "phaser";` ou importar símbolos específicos. **Isso é escopo do Gameplay Dev**, não do DevOps — mas significa que o próximo PR que entrar na `main` vai ser bloqueado pelo CI até isso ser consertado. O que é exatamente o comportamento desejado da branch protection.
+`npm run build` falha no scaffold atual por causa de `import Phaser from "phaser"` em `src/scenes/BootScene.ts` — Phaser 4 removeu o default export. Nota completa com fix sugerido em `docs/NOTES_FROM_DEVOPS.md`. O CI vai barrar o merge do PR do Gameplay Dev até isso ser consertado, que é exatamente o papel da branch protection.
 
 `npm run typecheck` passa limpo.
 
 ### Decisões pendentes
 
-- **Repo privado + branch protection**: GitHub Free não permite branch protection em repos privados. Opções: (a) tornar `os-cabra` público agora (menos atrito, combina com o "abrir pra público quando estiver apresentável" de `docs/DEVOPS.md` §1), (b) assinar GitHub Pro, (c) seguir sem proteção até um dos dois acontecer. Recomendo (a) ou (c) — o jogo não tem segredo no código.
 - Quando ativar o Vercel (Fase 2) — esperar M2 conforme `docs/prompts/07-devops.md`.
 - Domínio custom ou vercel.app? — aberto no `docs/DEVOPS.md` seção 9.
 - itch.io em paralelo ao Vercel ou só no release público? — aberto no `docs/DEVOPS.md` seção 9.

--- a/docs/REPORT_DEVOPS.md
+++ b/docs/REPORT_DEVOPS.md
@@ -1,0 +1,45 @@
+# Report DevOps
+
+## Fase 1 — Fundação (2026-04-19)
+
+### O que foi configurado
+
+- `.github/workflows/ci.yml` — CI em Node 22 rodando `typecheck` + `build` em cada PR e push na `main`. Job name: `build`.
+- `.github/ISSUE_TEMPLATE/bug.md` e `feature.md` — templates de issue.
+- `.github/pull_request_template.md` — template de PR com checklist.
+- `docs/DEVOPS_SETUP.md` — runbook com comandos usados (branch protection, reset, inspeção).
+- Branch protection em `main`: exige PR + 1 review + CI (`build`) verde + aplica a admins. Configurada via `gh api` (comando em `DEVOPS_SETUP.md`).
+
+### Comandos que o usuário precisa conhecer
+
+- **Abrir PR**: push em branch `feat/*` ou `chore/*`, depois `gh pr create`. `main` está travada, direct push falha.
+- **Inspecionar branch protection**: `gh api repos/giordanorec/os-cabra/branches/main/protection | jq`
+- **Desativar branch protection temporariamente** (emergência): comando em `docs/DEVOPS_SETUP.md`. **Sempre reativar depois.**
+- **Rodar CI localmente** antes de pushar: `npm run typecheck && npm run build`.
+
+### Blocker atual — build quebrado
+
+`npm run build` está falhando na `main`:
+
+```
+[MISSING_EXPORT] Error: "default" is not exported by "node_modules/phaser/dist/phaser.esm.js".
+  src/scenes/BootScene.ts:1:8
+  import Phaser from "phaser";
+```
+
+Causa: Phaser 4 não tem mais default export — é namespace import. Fix esperado: `import * as Phaser from "phaser";` ou importar símbolos específicos. **Isso é escopo do Gameplay Dev**, não do DevOps — mas significa que o próximo PR que entrar na `main` vai ser bloqueado pelo CI até isso ser consertado. O que é exatamente o comportamento desejado da branch protection.
+
+`npm run typecheck` passa limpo.
+
+### Decisões pendentes
+
+- Quando ativar o Vercel (Fase 2) — esperar M2 conforme `docs/prompts/07-devops.md`.
+- Domínio custom ou vercel.app? — aberto no `docs/DEVOPS.md` seção 9.
+- itch.io em paralelo ao Vercel ou só no release público? — aberto no `docs/DEVOPS.md` seção 9.
+
+### Próximos passos (Fase 2, quando M2 chegar)
+
+1. Conectar o repo no Vercel (GUI é mais simples que CLI pra setup inicial).
+2. Adicionar `vercel.json` na raiz (template em `docs/DEVOPS.md` seção 4.2).
+3. Documentar URL de produção no `README.md`.
+4. Atualizar este report com Fase 2.

--- a/docs/REPORT_DEVOPS.md
+++ b/docs/REPORT_DEVOPS.md
@@ -8,7 +8,7 @@
 - `.github/ISSUE_TEMPLATE/bug.md` e `feature.md` — templates de issue.
 - `.github/pull_request_template.md` — template de PR com checklist.
 - `docs/DEVOPS_SETUP.md` — runbook com comandos usados (branch protection, reset, inspeção).
-- Branch protection em `main`: exige PR + 1 review + CI (`build`) verde + aplica a admins. Configurada via `gh api` (comando em `DEVOPS_SETUP.md`).
+- Branch protection em `main`: **NÃO aplicada ainda** — GitHub responde `403 Upgrade to GitHub Pro or make this repository public`. Comando está pronto em `DEVOPS_SETUP.md`; basta o usuário tornar o repo público ou habilitar Pro e re-rodar o `gh api ... PUT`.
 
 ### Comandos que o usuário precisa conhecer
 
@@ -33,6 +33,7 @@ Causa: Phaser 4 não tem mais default export — é namespace import. Fix espera
 
 ### Decisões pendentes
 
+- **Repo privado + branch protection**: GitHub Free não permite branch protection em repos privados. Opções: (a) tornar `os-cabra` público agora (menos atrito, combina com o "abrir pra público quando estiver apresentável" de `docs/DEVOPS.md` §1), (b) assinar GitHub Pro, (c) seguir sem proteção até um dos dois acontecer. Recomendo (a) ou (c) — o jogo não tem segredo no código.
 - Quando ativar o Vercel (Fase 2) — esperar M2 conforme `docs/prompts/07-devops.md`.
 - Domínio custom ou vercel.app? — aberto no `docs/DEVOPS.md` seção 9.
 - itch.io em paralelo ao Vercel ou só no release público? — aberto no `docs/DEVOPS.md` seção 9.

--- a/docs/prompts/02-gameplay-dev.md
+++ b/docs/prompts/02-gameplay-dev.md
@@ -36,6 +36,7 @@ Toda a implementação em Phaser/TS. Cenas, entidades, sistemas, pools, physics,
 5. `docs/UX_SPEC.md` — HUD, textos, transições
 6. `src/config.ts` — constantes já definidas, você ajusta conforme `GDD.md`
 7. `src/main.ts` e `src/scenes/BootScene.ts` — ponto de partida atual
+8. `docs/NOTES_FROM_DEVOPS.md` — inbox do DevOps (blockers, estado do CI, coisas que te afetam agora)
 
 ## Verifique antes de começar
 


### PR DESCRIPTION
## Resumo
- CI (`.github/workflows/ci.yml`) rodando `typecheck` + `build` em Node 22 em cada push/PR contra `main`.
- Issue templates (`bug`, `feature`) e PR template em `.github/`.
- Runbook em `docs/DEVOPS_SETUP.md` com comandos de branch protection prontos pra uso.
- Report da Fase 1 em `docs/REPORT_DEVOPS.md`.

## Tipo de mudança
- [x] Chore/infra

## Status atual
- **CI**: configurado; **vai ficar vermelho no primeiro run** porque `npm run build` falha por causa de `import Phaser from "phaser"` em `src/scenes/BootScene.ts` — Phaser 4 não tem default export. Isso é escopo do Gameplay Dev; o CI está exatamente fazendo o trabalho dele (detectar o bug). Typecheck passa.
- **Branch protection**: comando pronto mas **não aplicado** — GitHub Free retorna 403 em repo privado. Precisa tornar `os-cabra` público ou migrar pra GitHub Pro. Ver `docs/REPORT_DEVOPS.md` e `docs/DEVOPS_SETUP.md`.

## Checklist
- [x] `npm run typecheck` limpo
- [ ] `npm run build` — falha por causa do bug acima
- [x] Docs atualizadas (`DEVOPS_SETUP.md`, `REPORT_DEVOPS.md`)

## Fase 2 (Vercel) — pendente
Esperar M2 conforme `docs/prompts/07-devops.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)