### PR TITLE
chore(vercel): Fase 2 — vercel.json + docs de deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 > Shoot 'em up vertical em Phaser 4 + TypeScript com tema das manifestações culturais do Recife.
 
-**Status**: setup concluído, aguardando implementação das especialidades.
+**Status**: Milestone 2 jogável em `main`. Próximo: boss da Fase 1 (M3).
 
-## Rodando
+## Jogar online
+
+Deploy automático na Vercel a cada push em `main`.
+
+- **Produção**: _URL será preenchida após o primeiro import na Vercel — ver `docs/DEVOPS_SETUP.md` §Fase 2._
+- **Preview por PR**: comentário automático do bot da Vercel em cada PR aberto.
+
+## Rodando localmente
 
 ```bash
 npm install

--- a/docs/DEVOPS_SETUP.md
+++ b/docs/DEVOPS_SETUP.md
@@ -65,9 +65,51 @@ gh api repos/giordanorec/os-cabra/branches/main/protection | jq
 
 GitHub pega esses arquivos automaticamente — não precisa ativar nada.
 
-## Fase 2 — Deploy (pendente)
+## Fase 2 — Deploy Vercel (2026-04-19)
 
-Acionada após o Gameplay Dev entregar M2 (primeiro milestone jogável). Ver `docs/DEVOPS.md` seção 4.2 pra Vercel.
+### `vercel.json`
+
+Na raiz do repo. Detectado automaticamente pela Vercel no import.
+
+```json
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": null,
+  "installCommand": "npm ci",
+  "cleanUrls": true
+}
+```
+
+### Importar o repo na Vercel (passo manual do usuário — crítico)
+
+Não dá pra automatizar: o Vercel CLI requer `vercel login` interativo e o MCP `deploy_to_vercel` só dá instruções. Também nenhuma das API calls disponíveis pelo MCP cria projeto.
+
+Passos (uma vez só, ~2 minutos):
+
+1. Ir em https://vercel.com/new
+2. Escolher o team `giordanorecs-projects`
+3. Selecionar o repo `giordanorec/os-cabra` da lista (repo é público desde Fase 1, aparece)
+4. Clicar **Import**
+5. Confirmar: Framework = `Other`, Build Command = `npm run build`, Output Directory = `dist`, Install Command = `npm ci` (o `vercel.json` já preenche)
+6. Clicar **Deploy**
+7. Após finalizar, copiar a URL de produção e colar no `README.md` (badge e seção "Jogar online")
+
+A partir desse ponto:
+
+- **Push em `main` → deploy de produção** automático.
+- **PR aberto → preview URL** automática como comentário no PR (cada commit no PR re-deploya a preview).
+
+### Env vars na Vercel
+
+Nenhuma exigida agora (jogo é 100% estático, sem backend, sem API key em runtime). Se algum dia precisar, ir em Project → Settings → Environment Variables. **Nunca commitar segredo no código.**
+
+### Rollback
+
+Na dashboard do projeto → Deployments → escolher um deploy anterior → "Promote to Production". Ou via Git: `git revert` do commit problemático + push em `main`.
+
+## Fase 3 — Polish (pendente)
 
 ## Fase 3 — Polish (pendente)
 

--- a/docs/REPORT_DEVOPS.md
+++ b/docs/REPORT_DEVOPS.md
@@ -18,21 +18,39 @@
 - **Desativar branch protection temporariamente** (emergência): comando em `docs/DEVOPS_SETUP.md`. **Sempre reativar depois.**
 - **Rodar CI localmente** antes de pushar: `npm run typecheck && npm run build`.
 
-### Blocker passado pro Gameplay Dev
+### Blocker passado pro Gameplay Dev (resolvido em M2)
 
-`npm run build` falha no scaffold atual por causa de `import Phaser from "phaser"` em `src/scenes/BootScene.ts` — Phaser 4 removeu o default export. Nota completa com fix sugerido em `docs/NOTES_FROM_DEVOPS.md`. O CI vai barrar o merge do PR do Gameplay Dev até isso ser consertado, que é exatamente o papel da branch protection.
+`npm run build` falhava no scaffold inicial por causa de `import Phaser from "phaser"` em `src/scenes/BootScene.ts`. **Resolvido** — com o merge do M2 (db97f38), o build passa limpo. Build gera `dist/index.html` (0.89 kB) + bundle JS ~1.37 MB. Warning de chunk size pode ser endereçado depois com code-splitting; não bloqueia deploy.
 
-`npm run typecheck` passa limpo.
+## Fase 2 — Deploy Vercel (2026-04-19)
+
+### O que foi configurado
+
+- `vercel.json` na raiz do repo — `buildCommand: npm run build`, `outputDirectory: dist`, `installCommand: npm ci`, `framework: null`, `cleanUrls: true`.
+- Vercel MCP confirma que a conta `giordanorec` tem 1 team (`giordanorecs-projects`) e 2 projetos existentes (`mapaproteico`, `mang-ia`) — projeto `os-cabra` **ainda não existe** na Vercel.
+- Build local validado: `npm run build` passa em ~2s e gera `dist/` com `index.html` + `assets/index-*.js`.
+
+### Ação manual do usuário (crítico — não dá pra automatizar)
+
+O Vercel CLI requer `vercel login` interativo (abre browser) e o MCP `deploy_to_vercel` só retorna instruções, não deploya. Pra finalizar:
+
+1. Abrir https://vercel.com/new
+2. Selecionar o repo `giordanorec/os-cabra` (público desde Fase 1, aparece na lista)
+3. Clicar **Import**
+4. Vercel detecta automaticamente o `vercel.json` — build command e output já vêm preenchidos
+5. Framework Preset: deixar **Other** (`framework: null` no json)
+6. Clicar **Deploy**
+7. Após o primeiro deploy, copiar a URL de produção (ex: `os-cabra.vercel.app` ou `os-cabra-giordanorecs-projects.vercel.app`)
+8. Rodar no repo: atualizar o badge no `README.md` e atualizar este report com a URL real
+
+A partir daí, cada merge em `main` dispara um deploy de produção automaticamente. Cada PR ganha uma preview URL automática.
+
+### URL de produção
+
+**Pendente** — preencher após o Import na dashboard. Placeholder no `README.md` com instruções.
 
 ### Decisões pendentes
 
-- Quando ativar o Vercel (Fase 2) — esperar M2 conforme `docs/prompts/07-devops.md`.
-- Domínio custom ou vercel.app? — aberto no `docs/DEVOPS.md` seção 9.
-- itch.io em paralelo ao Vercel ou só no release público? — aberto no `docs/DEVOPS.md` seção 9.
-
-### Próximos passos (Fase 2, quando M2 chegar)
-
-1. Conectar o repo no Vercel (GUI é mais simples que CLI pra setup inicial).
-2. Adicionar `vercel.json` na raiz (template em `docs/DEVOPS.md` seção 4.2).
-3. Documentar URL de produção no `README.md`.
-4. Atualizar este report com Fase 2.
+- Domínio custom (`oscabra.com`, `oscabra.pe`) ou ficar em `*.vercel.app`? — aberto.
+- itch.io em paralelo ao Vercel ou só no release público? — aberto.
+- Bundle de ~1.37 MB: endereçar com code-splitting em milestone de polish, não agora.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": null,
+  "installCommand": "npm ci",
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Resumo
- `vercel.json` na raiz: build=\`npm run build\`, output=\`dist\`, install=\`npm ci\`, framework=\`null\`, cleanUrls.
- `README.md` ganha seção "Jogar online" com placeholder de URL.
- `docs/DEVOPS_SETUP.md` §Fase 2 — passos manuais pro usuário importar o repo em vercel.com/new.
- `docs/REPORT_DEVOPS.md` — Fase 2 em andamento, blocker do import Phaser marcado como resolvido no M2.

## Tipo de mudança
- [x] Chore/infra

## Ação manual do usuário (crítica)
Não consegui automatizar a criação do projeto na Vercel:
- Vercel CLI exige \`vercel login\` interativo (abre browser).
- MCP \`deploy_to_vercel\` só retorna instruções, não deploya.
- MCP Vercel confirma que o team \`giordanorecs-projects\` existe e tem 2 projetos (\`mapaproteico\`, \`mang-ia\`), mas \`os-cabra\` não.

Depois que esse PR for mergeado, fazer em https://vercel.com/new (~2 min):

1. Selecionar o repo \`giordanorec/os-cabra\`
2. Clicar **Import** (\`vercel.json\` preenche build/output automaticamente)
3. Framework Preset: **Other**
4. **Deploy**
5. Copiar a URL de produção e atualizar o \`README.md\` + \`REPORT_DEVOPS.md\`

A partir daí, deploy automático em cada merge na \`main\` + preview por PR.

## Checklist
- [x] \`npm run typecheck\` limpo
- [x] \`npm run build\` validado localmente (gera \`dist/\`, ~2s)
- [x] Docs atualizadas (\`DEVOPS_SETUP.md\`, \`REPORT_DEVOPS.md\`, \`README.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)