### PR TITLE
fix(vercel): trocar npm ci por npm install (tolera lockfile parcial)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,6 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": null,
-  "installCommand": "npm ci",
+  "installCommand": "npm install --no-audit --no-fund",
   "cleanUrls": true
 }


### PR DESCRIPTION
Deploy da production falha com npm ci (estrito) pois o lockfile, apesar de regenerado, continua sem gravar optional deps cross-platform por bug do npm 10 + vite 8 + rolldown. npm install resolve ao vivo e passa. Trade-off: perdemos determinismo forte, ganhamos robustez — ok pra projeto pessoal.