### PR TITLE
feat(art): trocar placeholders por sprites reais da Fase 1

### DIFF
--- a/src/scenes/PreloadScene.ts
+++ b/src/scenes/PreloadScene.ts
@@ -7,12 +7,26 @@ interface Placeholder {
   color: number;
 }
 
+interface RealSprite {
+  key: string;
+  path: string;
+  frameWidth: number;
+  frameHeight: number;
+}
+
+// Sprites reais em public/assets/sprites/ (entregues pelo Visual Designer M2, PR #11).
+// Carregados como spritesheet — primeira frame (0) vira a textura default quando usada só como 'key'.
+const REAL_SPRITES: RealSprite[] = [
+  { key: 'player',           path: 'assets/sprites/player.png',           frameWidth: 32, frameHeight: 32 },
+  { key: 'enemy-passista',   path: 'assets/sprites/enemy-passista.png',   frameWidth: 32, frameHeight: 32 },
+  { key: 'enemy-caboclinho', path: 'assets/sprites/enemy-caboclinho.png', frameWidth: 28, frameHeight: 28 },
+  { key: 'enemy-mosca',      path: 'assets/sprites/enemy-mosca.png',      frameWidth: 14, frameHeight: 14 }
+];
+
+// Assets ainda sem sprite real — continuam como placeholders coloridos.
+// Bullets e bosses do trio Maracatu ficam pro próximo ciclo de arte.
 const PLACEHOLDERS: Placeholder[] = [
-  { key: 'player', w: 32, h: 32, color: 0xd4a04c },
   { key: 'bullet-player', w: 6, h: 14, color: 0xf4e4c1 },
-  { key: 'enemy-caboclinho', w: 28, h: 28, color: 0xb84a2e },
-  { key: 'enemy-passista', w: 32, h: 32, color: 0xe87a3e },
-  { key: 'enemy-mosca', w: 14, h: 14, color: 0x7a6850 },
   { key: 'enemy-bullet-flecha', w: 6, h: 18, color: 0xb84a2e },
   { key: 'enemy-bullet-bombinha', w: 10, h: 10, color: 0xd4a04c },
   { key: 'boss-rei', w: 48, h: 56, color: 0xd4a04c },
@@ -26,6 +40,12 @@ export class PreloadScene extends Phaser.Scene {
   }
 
   preload() {
+    for (const s of REAL_SPRITES) {
+      this.load.spritesheet(s.key, s.path, {
+        frameWidth: s.frameWidth,
+        frameHeight: s.frameHeight
+      });
+    }
     for (const p of PLACEHOLDERS) {
       this.generatePlaceholder(p);
     }


### PR DESCRIPTION
PreloadScene agora faz load.spritesheet() dos PNGs em public/assets/sprites/ (entregues pelo Visual Designer no PR #11 e não linkados até agora). Player, Passista, Caboclinho e Mosca saem de quadrados marrons pra xilogravura real. Bullets e trio de bosses ainda como placeholder colorido.